### PR TITLE
Refactor variances router

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,6 @@ DEBUG=false
 
 DB_URL_LOCAL=postgresql://postgres:postgres@localhost:5432/postgres
 DB_URL_PROD=postgresql://postgres:postgres@db:5432/shop
+
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim
 
 WORKDIR /backend/app
 
-RUN pip install --no-cache-dir fastapi uvicorn psycopg2-binary alembic sqlmodel python-dotenv
+RUN pip install --no-cache-dir fastapi uvicorn psycopg2-binary alembic sqlmodel python-dotenv celery redis
 
 COPY ./app /backend/app
 

--- a/backend/alembic/versions/19f1e3d1fd11_add_basket_item_table.py
+++ b/backend/alembic/versions/19f1e3d1fd11_add_basket_item_table.py
@@ -1,0 +1,46 @@
+"""add basket item table
+
+Revision ID: 19f1e3d1fd11
+Revises: 4d771dbeeebb
+Create Date: 2025-01-28 15:45:22.890050
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '19f1e3d1fd11'
+down_revision: Union[str, None] = '4d771dbeeebb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.create_table(
+        'basket_item',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column(
+            'basket_id',
+            sa.Integer,
+            sa.ForeignKey('basket.id', ondelete='CASCADE'),
+            nullable=False
+        ),
+        sa.Column(
+            'variance_id',
+            sa.Integer,
+            sa.ForeignKey('variance.id', ondelete='CASCADE'),
+            nullable=False
+        ),
+        sa.Column('amount', sa.Integer),
+        sa.Column('base_price', sa.Float, nullable=True),
+        sa.Column('variance_price', sa.Float, nullable=True),
+    )
+    pass
+
+
+def downgrade():
+    op.drop_table('basket_item')
+    pass

--- a/backend/alembic/versions/3d0481fff148_add_order_table.py
+++ b/backend/alembic/versions/3d0481fff148_add_order_table.py
@@ -1,0 +1,42 @@
+"""add order table
+
+Revision ID: 3d0481fff148
+Revises: 19f1e3d1fd11
+Create Date: 2025-01-29 14:06:26.891352
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3d0481fff148'
+down_revision: Union[str, None] = '19f1e3d1fd11'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.create_table(
+        'order',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('payment_secret', sa.String(), nullable=True),
+        sa.Column('shipping_address', sa.String(), nullable=True),
+        sa.Column('billing_address', sa.String(), nullable=True),
+        sa.Column('payment_method', sa.String(), nullable=True),
+        sa.Column('payed', sa.Boolean(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column(
+            'basket_id',
+            sa.Integer,
+            sa.ForeignKey('basket.id', ondelete='CASCADE'),
+            nullable=False
+        ),
+    )
+    pass
+
+def downgrade():
+    op.drop_table('order')
+    pass

--- a/backend/alembic/versions/4d771dbeeebb_add_basket_table.py
+++ b/backend/alembic/versions/4d771dbeeebb_add_basket_table.py
@@ -1,0 +1,36 @@
+"""add basket table
+
+Revision ID: 4d771dbeeebb
+Revises: 6542823e28eb
+Create Date: 2025-01-28 14:51:59.359240
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4d771dbeeebb'
+down_revision: Union[str, None] = '6542823e28eb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.create_table(
+        'basket',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column(
+            'user_id',
+            sa.Integer,
+            sa.ForeignKey('product.id', ondelete='CASCADE'),
+            nullable=False
+        ),
+    )
+    pass
+
+def downgrade():
+    op.drop_table('basket')
+    pass

--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -1,7 +1,7 @@
 import time
 
 from fastapi import FastAPI
-from routers import user_router, product_router, variance_router
+from routers import user_router, product_router, variance_router, user_basket_router, order_user_router
 from db.engine import DatabaseManager
 
 from dotenv import load_dotenv
@@ -16,7 +16,9 @@ app = FastAPI()
 app.include_router(user_router.router)
 app.include_router(product_router.router)
 app.include_router(variance_router.router)
+app.include_router(user_basket_router.router)
+app.include_router(order_user_router.router)
 
 @app.get("/")
 def read_root():
-    return "123"
+    return "Welcome to our shop!"

--- a/backend/app/enums/enums.py
+++ b/backend/app/enums/enums.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class OrderStatus(str, Enum):
+    PENDING = "pending"
+    PAYMENT_STARTED = "payment_started"
+    PAYMENT_COMPLETED = "payment_completed"
+    SHIPPED = "shipped"
+    DELIVERED = "delivered"
+    CANCELED = "canceled"

--- a/backend/app/models/base_model.py
+++ b/backend/app/models/base_model.py
@@ -1,20 +1,30 @@
 from sqlmodel import SQLModel
 
 class BaseModel(SQLModel, table=False):
-    def append_relation(self, model_dict, relation_name):
-        relation = getattr(self, relation_name, None)
-        if relation is not None:
-            if isinstance(relation, list):
-                model_dict[relation_name] = [item.dict() for item in relation]
-            else:
-                model_dict[relation_name] = relation.dict()
-        return model_dict
-
     def load_relations(self, relations_to_load=None):
         model_dict = self.dict()
 
         if relations_to_load:
             for relation_name in relations_to_load:
-                model_dict = self.append_relation(model_dict, relation_name)
+                relation_parts = relation_name.split('.')
+                model_dict = self._load_nested_relation(model_dict, relation_parts)
+
+        return model_dict
+
+    def _load_nested_relation(self, model_dict, relation_parts):
+        relation_name = relation_parts[0]
+        relation = getattr(self, relation_name, None)
+
+        if relation:
+            if isinstance(relation, list):
+                model_dict[relation_name] = [
+                    item.
+                    load_relations(['.'.join(relation_parts[1:])]) if relation_parts[1:] else item.dict()
+                    for item in relation
+                ]
+            else:
+                model_dict[relation_name] = (
+                    relation
+                    .load_relations(['.'.join(relation_parts[1:])])) if relation_parts[1:] else relation.dict()
 
         return model_dict

--- a/backend/app/models/basket.py
+++ b/backend/app/models/basket.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from sqlmodel import Field, SQLModel, Relationship
+from models.base_model import BaseModel
+
+class Basket(BaseModel, table=True):
+    id: int = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id")
+    user: "User" = Relationship(back_populates="baskets")
+    basket_items: List["BasketItem"] = Relationship(back_populates="basket")
+    order: "Order"= Relationship(back_populates="basket")

--- a/backend/app/models/basket_item.py
+++ b/backend/app/models/basket_item.py
@@ -1,0 +1,13 @@
+from sqlmodel import Field, SQLModel, Relationship
+from models.base_model import BaseModel
+from typing import Optional
+
+class BasketItem(BaseModel, table=True):
+    id: int = Field(default=None, primary_key=True)
+    variance_id: int = Field(foreign_key="variance.id")
+    basket_id: int = Field(foreign_key="basket.id")
+    amount: int
+    base_price: Optional[float] = Field(default=None, nullable=True)
+    variance_price: Optional[float] = Field(default=None, nullable=True)
+    basket: "Basket" = Relationship(back_populates="basket_items")
+    variance: "Variance" = Relationship(back_populates="basket_items")

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,0 +1,123 @@
+from sqlmodel import Field, SQLModel, Relationship, select, Session
+from models.base_model import BaseModel
+from models.basket import Basket
+from typing import Optional
+from datetime import datetime, timedelta
+from tasks.celery_app import celery_app
+from db.engine import get_session
+import random
+from enums.enums import OrderStatus
+
+class Order(BaseModel, table=True):
+    id: int = Field(default=None, primary_key=True)
+    shipping_address: Optional["str"]
+    billing_address: Optional["str"]
+    payment_method: Optional["str"]
+    payment_secret: Optional["str"]
+    payed: bool
+    status: str
+    basket_id: int = Field(default=None, foreign_key="basket.id")
+    basket: "Basket" = Relationship(back_populates="order")
+
+    def current_payment_secret(self, session: Session):
+        if not self.payment_secret:
+            self.status = OrderStatus.PAYMENT_STARTED.value
+
+            session.add(self)
+            session.commit()
+
+            self.create_payment_secret(session)
+
+            session.refresh(self)
+
+        return self.payment_secret
+
+    def set_basket_items_price(self, session: Session):
+        # Right here, the basket_items prices will be set to the current prices.
+        # If the prices for a product or its variance will be edited this won't
+        # affect the order and the prices at the time when it was bought will be
+        # kept to be able to do refunds if necessary.
+
+        for basket_item in self.basket.basket_items:
+            basket_item.base_price = basket_item.variance.product.base_price
+            basket_item.variance_price = basket_item.variance.price
+
+            session.add(basket_item)
+            session.commit()
+
+    def create_payment_secret(self, session: Session):
+        # I looked up on the internet how the payment process would work.
+        # Assuming we are for now supporting PayPal only, the backend
+        # would create some secret string with the PayPal API containing
+        # how much has to be paid to which account. This secret is here
+        # passed back to the frontend. With this secret in the frontend
+        # the PayPal window can be opened showing the user what he is paying
+        # for. To the secret via a standard format the order details can
+        # be added to, so the user can lookup in the PayPal window what
+        # he/she is paying for.
+
+        # So here the PayPal API would be called and the secret would be created.
+        payment_secret = "Some secret containing payment method, order details and who to pay to."
+
+        self.payment_secret = payment_secret
+
+        session.add(self)
+        session.commit()
+
+        return payment_secret
+
+    def is_payed(self, session: Session):
+        # Right here, after the user calls the API to tell the payment
+        # process is done, the order itself checks whether this is true
+        # based on the secret. If it is the function returns true to finish
+        # the order.
+        payed = random.choice([True, False])
+
+        if not payed:
+            return False
+
+        self.payed = True
+        self.status = OrderStatus.PAYMENT_COMPLETED.value
+
+        session.add(self)
+        session.commit()
+
+        return self.id
+
+    def pay_money_back(self):
+        print("The money is payed back to the user.")
+
+class TaskOrder:
+    def __init__(self, order_id: int, expiration_minutes: int = 30):
+        self.order_id = order_id
+        self.expiration_time = datetime.utcnow() + timedelta(minutes=expiration_minutes)
+
+    def start_expiration_timer(self):
+        expire_order.apply_async(args=[self.order_id], eta=self.expiration_time)
+        print(f"Order {self.order_id} will expire at {self.expiration_time}")
+
+@celery_app.task
+def expire_order(order_id: int):
+    session = get_session()
+    statement = select(Order).where(Order.id == order_id)
+    order = session.exec(statement).first()
+
+    statement = select(Basket).where(Basket.idf == order.basket_id)
+    basket = session.exec(statement).first()
+    if order and order.status != OrderStatus.PAYMENT_COMPLETED.value:
+        session.delete(basket)
+        session.commit()
+
+        # When the user payed in the popout window of paypal but didn't
+        # afterwards no our website again confirm the purchase, the money
+        # will be payed back to the user and the order is deleted/cancelled.
+        if order.is_payed(session):
+            order.pay_money_back()
+
+        # TODO: If the order expired and wasn't finished the items reserved in the storage
+        # have to be freed again.
+
+        session.delete(order)
+        session.commit()
+
+    session.close()

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,9 +1,84 @@
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, SQLModel, Relationship, select, Session, or_
+from typing import List
+from models.base_model import BaseModel
+from models.basket import Basket
+from models.order import Order
+from db.engine import get_session
+from enums.enums import OrderStatus
 
-class User(SQLModel, table=True):
+from models.order import TaskOrder
+
+from models.basket_item import BasketItem
+
+class User(BaseModel, table=True):
     id: int = Field(default=None, primary_key=True)
     first_name: str
     last_name: str
     email: str
     password: str
     address: str
+    baskets: List["Basket"] = Relationship(back_populates="user", cascade_delete=True)
+
+    @staticmethod
+    def get_user(user_id: int):
+        statement = select(User).where(User.id == user_id)
+
+        return get_session().exec(statement).first()
+
+    def get_current_basket(self, session: Session):
+        statement = (
+            select(Basket)
+            .where(Basket.user_id == self.id)
+            .order_by(Basket.id.desc())
+            .limit(1)
+        )
+        basket = session.exec(statement).first()
+
+        order = None
+        if basket is not None:
+            # The order in which the current basket might be included at the moment is
+            # fetched, so it can be checked whether the current orders exists and the
+            #  status is still pending. Only that allows the user to still edit it.
+            order = session.exec(select(Order).where(Order.basket_id == basket.id)).first()
+
+        if basket is None or (order is not None and order.status != OrderStatus.PENDING.value):
+            basket = new_basket = Basket(user_id=self.id)
+            session.add(new_basket)
+            session.commit()
+            session.refresh(new_basket)
+
+        return basket
+
+    def get_current_order(self, session: Session):
+        statement = (select(Order)
+                     .join(Basket)
+                     .where(Basket.user_id == self.id)
+                     .where(or_(Order.status == OrderStatus.PENDING.value,
+                                Order.status == OrderStatus.PAYMENT_STARTED.value)))
+
+        order = session.exec(statement).first()
+
+        if order is None:
+            basket = self.get_current_basket(session)
+
+            if not basket:
+                return None
+
+            basket_items = session.exec(select(BasketItem).where(BasketItem.basket_id == basket.id)).first()
+
+            if not basket_items:
+                return None
+
+            order = new_order = Order(
+                basket_id=self.get_current_basket(session).id,
+                payed=False,
+                status=OrderStatus.PENDING.value,
+            )
+            session.add(new_order)
+            session.commit()
+            session.refresh(new_order)
+
+            task = TaskOrder(new_order.id)
+            task.start_expiration_timer()
+
+        return order

--- a/backend/app/models/variance.py
+++ b/backend/app/models/variance.py
@@ -1,6 +1,8 @@
 from sqlmodel import Field, SQLModel, Relationship
 from models.base_model import BaseModel
 
+from typing import List
+
 class Variance(BaseModel, table=True):
     id: int = Field(default=None, primary_key=True)
     product_id: int = Field(foreign_key="product.id")
@@ -8,3 +10,4 @@ class Variance(BaseModel, table=True):
     variance_type: str
     price: float
     product: "Product" = Relationship(back_populates="variances")
+    basket_items: List["BasketItem"] = Relationship(back_populates="variance")

--- a/backend/app/routers/order_user_router.py
+++ b/backend/app/routers/order_user_router.py
@@ -1,0 +1,156 @@
+from sqlmodel import Session, SQLModel, select
+from models.user import User
+
+from db.engine import DatabaseManager, get_session
+
+from fastapi import APIRouter, Request, HTTPException, Depends, Query
+
+from enums.enums import OrderStatus
+
+NO_USER_DESCRIPTION = "The ID of the user whose basket is requested"
+
+router = APIRouter(
+    prefix="/current-order",
+    tags=["order"],
+)
+
+def check_user_and_order_existence(session: Session, user_id: int):
+    user = User.get_user(user_id)
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found.")
+
+    order = user.get_current_order(session)
+
+    if order is None:
+        raise HTTPException(status_code=400, detail="No order found.")
+
+    return order
+
+@router.put("/")
+def get_current_order(session: Session = Depends(get_session), user_id: int = Query(..., description=NO_USER_DESCRIPTION)):
+    user = User.get_user(user_id)
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    order = check_user_and_order_existence(session, user_id).load_relations(["basket.basket_items.variance.product"])
+
+    session.close()
+
+    return order
+
+@router.put("/add-shipping-address")
+async def add_shipping_address(request: Request, session: Session = Depends(get_session), user_id: int = Query(..., description=NO_USER_DESCRIPTION)):
+    order = check_user_and_order_existence(session, user_id)
+
+    if order.status != OrderStatus.PENDING.value:
+        raise HTTPException(status_code=400, detail="Order not pending.")
+
+    data = await request.json()
+
+    order.shipping_address = data.get("shipping_address")
+
+    session.add(order)
+    session.commit()
+
+    session.refresh(order)
+
+    order = order.load_relations(["basket.basket_items.variance.product"])
+
+    session.close()
+
+    return order
+
+@router.put("/add-billing-address")
+async def add_billing_address(request: Request, session: Session = Depends(get_session), user_id: int = Query(..., description=NO_USER_DESCRIPTION)):
+    order = check_user_and_order_existence(session, user_id)
+
+    if order.status != OrderStatus.PENDING.value:
+        raise HTTPException(status_code=400, detail="Order not pending.")
+
+    data = await request.json()
+
+    if data.get("same_as_shipping_address", False):
+        billing_address = order.shipping_address
+    else:
+        billing_address = data.get("billing_address")
+
+    order.billing_address = billing_address
+
+    session.add(order)
+    session.commit()
+
+    session.refresh(order)
+
+    order = order.load_relations(["basket.basket_items.variance.product"])
+
+    session.close()
+
+    return order
+
+@router.put("/add-payment-method")
+async def add_payment_method(request: Request, session: Session = Depends(get_session), user_id: int = Query(..., description=NO_USER_DESCRIPTION)):
+    order = check_user_and_order_existence(session, user_id)
+
+    if order.status != OrderStatus.PENDING.value:
+        raise HTTPException(status_code=400, detail="Order not pending.")
+
+    data = await request.json()
+
+    order.payment_method = data.get("payment_method")
+
+    session.add(order)
+    session.commit()
+
+    session.refresh(order)
+
+    order.load_relations(["basket.basket_items.variance.product"])
+
+    session.close()
+
+    return order
+
+@router.put("/pay")
+async def pay(session: Session = Depends(get_session), user_id: int = Query(..., description=NO_USER_DESCRIPTION)):
+    order = check_user_and_order_existence(session, user_id)
+
+    # TODO: Here, the items included in the order should be reserved from the storage
+    # so they are marked as sold until the order is finished and they are really sold
+    # or the order is cancelled for some reason an the items can be added to the storage
+    # again.
+
+    if order.status != OrderStatus.PENDING.value and order.status != OrderStatus.PAYMENT_STARTED.value:
+        raise HTTPException(status_code=400, detail="Order not pending.")
+
+    if order.shipping_address is None or order.billing_address is None or order.payment_method is None:
+        raise HTTPException(status_code=400, detail="There aren't yet all order information provided.")
+
+    payment_secret = order.current_payment_secret(session)
+
+    order.set_basket_items_price(session)
+
+    session.close()
+
+    return payment_secret
+
+@router.post("/checkout")
+async def checkout(session: Session = Depends(get_session), user_id: int = Query(..., description=NO_USER_DESCRIPTION)):
+    order = check_user_and_order_existence(session, user_id)
+
+    if order.status != OrderStatus.PAYMENT_STARTED.value:
+        raise HTTPException(status_code=400, detail="Order not pending.")
+
+    if order.payed:
+        raise HTTPException(status_code=400, detail="Payment already confirmed.")
+
+    if not order.is_payed(session):
+        raise HTTPException(status_code=404, detail="Couldn't confirm the payment.")
+
+    order = order.load_relations(["basket.basket_items.variance.product"])
+
+    session.close()
+
+    # TODO: A confirmation mail needs to be send.
+
+    return order

--- a/backend/app/routers/product_router.py
+++ b/backend/app/routers/product_router.py
@@ -17,6 +17,8 @@ def get_all_products(session: Session = Depends(get_session)):
 
     products = [product.load_relations(relations_to_load=["variances"]) for product in products]
 
+    session.close()
+
     return products
 
 @router.get("/{product_id}")
@@ -27,7 +29,11 @@ def get_product_by_id(product_id: int, session: Session = Depends(get_session)):
     if product is None:
         raise HTTPException(status_code=404, detail="Product not found.")
 
-    return product.load_relations(relations_to_load=["variances"])
+    product = product.load_relations(relations_to_load=["variances"])
+
+    session.close()
+
+    return product
 
 @router.post("/")
 async def create_product(request: Request, session: Session = Depends(get_session)):
@@ -55,7 +61,11 @@ async def create_product(request: Request, session: Session = Depends(get_sessio
 
     session.refresh(new_product)
 
-    return new_product.load_relations(relations_to_load=["variances"])
+    new_product =new_product.load_relations(relations_to_load=["variances"])
+
+    session.close()
+
+    return new_product
 
 @router.patch("/{product_id}")
 async def update_product(product_id: int, request: Request, session: Session = Depends(get_session)):
@@ -76,7 +86,11 @@ async def update_product(product_id: int, request: Request, session: Session = D
 
     session.refresh(product)
 
-    return product.load_relations(relations_to_load=["variances"])
+    product = product.load_relations(relations_to_load=["variances"])
+
+    session.close()
+
+    return product
 
 @router.delete("/{product_id}")
 def delete_product(product_id: int, session: Session = Depends(get_session)):
@@ -87,5 +101,7 @@ def delete_product(product_id: int, session: Session = Depends(get_session)):
 
     session.delete(product)
     session.commit()
+
+    session.close()
 
     return {"message": "Product deleted successfully."}

--- a/backend/app/routers/user_basket_router.py
+++ b/backend/app/routers/user_basket_router.py
@@ -1,0 +1,184 @@
+from sqlmodel import Session, SQLModel, select
+from models.user import User
+from models.variance import Variance
+from models.basket_item import BasketItem
+from models.basket import Basket
+from models.order import Order
+
+from db.engine import DatabaseManager, get_session
+
+from fastapi import APIRouter, Request, HTTPException, Depends, Query
+
+router = APIRouter(
+    prefix="/current-basket",
+    tags=["current-basket"]
+)
+
+def get_basket_item(user: User, basket_item_id: int, session: Session):
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    basket = user.get_current_basket(session)
+
+    statement = select(BasketItem).where(BasketItem.id == basket_item_id).where(BasketItem.basket_id == basket.id)
+    basket_item = session.exec(statement).first()
+
+    if basket_item is None:
+        raise HTTPException(status_code=404, detail="BasketItem not found.")
+
+    return basket_item
+
+# The decision was made to only allow orders having basket which has at least
+# one BasketItem. When a BasketItem is removed and the Basket gets empty,
+# the order has to be removed as well.
+def check_existing_order_must_be_deleted(basket: Basket ,session: Session):
+    statement = select(BasketItem).where(BasketItem.basket_id == basket.id)
+    basket_item = session.exec(statement).first()
+
+    statement = select(Order).where(Order.basket_id == basket.id)
+    order = session.exec(statement).first()
+
+    if basket_item is None and order is not None:
+        session.delete(order)
+        session.commit()
+
+@router.put("/")
+def get_current_basket(session: Session = Depends(get_session), user_id: int = Query(..., description="The ID of the user whose basket is requested")):
+    user = User.get_user(user_id)
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    basket = user.get_current_basket(session).load_relations(relations_to_load=['basket_items'])
+
+    session.close()
+
+    return basket
+
+@router.post("/add-item")
+async def add_item_to_current_basket(request: Request, session: Session = Depends(get_session), user_id: int = Query(..., description="The ID of the user whose basket is requested")):
+    user = User.get_user(user_id)
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    basket = user.get_current_basket(session)
+
+    item_data = await request.json()
+
+    variance_id = item_data.get("variance_id")
+    amount = item_data.get("amount")
+
+    statement = select(Variance).where(Variance.id == variance_id)
+    variance = session.exec(statement).first()
+
+    if variance is None:
+        raise HTTPException(status_code=404, detail="Variance not found.")
+
+    statement = (select(BasketItem)
+                 .where(BasketItem.variance_id == variance.id)
+                 .where(BasketItem.basket_id == basket.id))
+
+    if session.exec(statement).first() is not None:
+        raise HTTPException(status_code=400, detail="A BasketItem with for this variance already exists.")
+
+    basket_item = BasketItem(
+        basket_id=basket.id,
+        variance_id=variance_id,
+        amount=amount,
+        base_price=None,
+        variance_price=None
+    )
+    session.add(basket_item)
+    session.commit()
+
+    session.refresh(basket_item)
+
+    basket = basket.load_relations(relations_to_load=['basket_items'])
+
+    session.close()
+
+    return basket
+
+@router.delete("/remove-item/{basket_item_id}")
+async def add_item_to_current_basket(basket_item_id: int, session: Session = Depends(get_session), user_id: int = Query(..., description="The ID of the user whose basket is requested")):
+    basket_item = get_basket_item(User.get_user(user_id), basket_item_id, session)
+
+    basket = basket_item.basket
+
+    session.delete(basket_item)
+    session.commit()
+
+    check_existing_order_must_be_deleted(basket, session)
+
+    session.close()
+
+    return {"message": "BasketItem deleted successfully."}
+
+@router.put("/item/{basket_item_id}/add")
+async def add_item_to_current_basket(basket_item_id: int, request: Request, session: Session = Depends(get_session), user_id: int = Query(..., description="The ID of the user whose basket is requested")):
+    basket_item = get_basket_item(User.get_user(user_id), basket_item_id, session)
+
+    try:
+        item_data = await request.json()
+    except Exception as e:
+        item_data = {}
+
+    additional_amount = item_data.get("additional_amount", None)
+
+    if additional_amount:
+        if additional_amount < 0:
+            raise HTTPException(status_code=400, detail="Additional amount must be greater than 0.")
+
+        basket_item.amount += additional_amount
+    else:
+        basket_item.amount += 1
+
+    session.add(basket_item)
+    session.commit()
+
+    user = User.get_user(user_id)
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    basket = user.get_current_basket(session).load_relations(relations_to_load=['basket_items'])
+
+    session.close()
+
+    return basket
+
+@router.put("/item/{basket_item_id}/remove")
+async def remove_item_from_current_basket(basket_item_id: int, request: Request, session: Session = Depends(get_session), user_id: int = Query(..., description="The ID of the user whose basket is requested")):
+    basket_item = get_basket_item(User.get_user(user_id), basket_item_id, session)
+
+    try:
+        item_data = await request.json()
+    except Exception as e:
+        item_data = {}
+
+    removal_amount = item_data.get("removal_amount", None)
+
+    if removal_amount:
+        if removal_amount < 0:
+            raise HTTPException(status_code=400, detail="Additional amount must be greater than 0.")
+        basket_item.amount -= removal_amount
+    else:
+        basket_item.amount -= 1
+
+    if basket_item.amount < 1:
+        raise HTTPException(status_code=400, detail="Amount cannot go below 1.")
+
+    session.add(basket_item)
+    session.commit()
+
+    user = User.get_user(user_id)
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    basket = user.get_current_basket(session).load_relations(relations_to_load=['basket_items'])
+
+    session.close()
+
+    return basket

--- a/backend/app/routers/user_router.py
+++ b/backend/app/routers/user_router.py
@@ -15,6 +15,8 @@ def get_all_users(session: Session = Depends(get_session)):
     statement = select(User)
     users = session.exec(statement).all()
 
+    session.close()
+
     return users
 
 @router.get("/{user_id}")
@@ -24,6 +26,8 @@ def get_user_by_id(user_id: int, session: Session = Depends(get_session)):
 
     if user is None:
         raise HTTPException(status_code=404, detail="User not found.")
+
+    session.close()
 
     return user
 
@@ -49,6 +53,8 @@ async def create_user(request: Request, session: Session = Depends(get_session))
 
     session.refresh(new_user)
 
+    session.close()
+
     return new_user
 
 @router.patch("/{user_id}")
@@ -70,6 +76,8 @@ async def update_user(user_id: int, request: Request, session: Session = Depends
 
     session.refresh(user)
 
+    session.close()
+
     return user
 
 
@@ -82,5 +90,7 @@ def delete_user(user_id: int, session: Session = Depends(get_session)):
 
     session.delete(user)
     session.commit()
+
+    session.close()
 
     return {"message": "User deleted successfully."}

--- a/backend/app/routers/variance_router.py
+++ b/backend/app/routers/variance_router.py
@@ -25,6 +25,8 @@ def get_all_variances(product_id, session: Session = Depends(get_session)):
     statement = select(Variance).where(Variance.product_id == product_id)
     variances = session.exec(statement).all()
 
+    session.close()
+
     return variances
 
 @router.get("/{variance_id}")
@@ -34,6 +36,8 @@ def get_variance_by_id(variance_id: int, session: Session = Depends(get_session)
 
     if variance is None:
         raise HTTPException(status_code=404, detail="Variance not found.")
+
+    session.close()
 
     return variance
 
@@ -61,6 +65,8 @@ async def create_variance(product_id: int, request: Request, session: Session = 
 
     session.refresh(new_variance)
 
+    session.close()
+
     return new_variance
 
 @router.patch("/{variance_id}")
@@ -82,6 +88,8 @@ async def update_variance(variance_id: int, request: Request, session: Session =
 
     session.refresh(variance)
 
+    session.close()
+
     return variance
 
 
@@ -95,5 +103,7 @@ def delete_user(variance_id: int, session: Session = Depends(get_session)):
 
     session.delete(variance)
     session.commit()
+
+    session.close()
 
     return {"message": "Variance deleted successfully."}

--- a/backend/app/routers/variance_router.py
+++ b/backend/app/routers/variance_router.py
@@ -18,8 +18,6 @@ def get_all_variances(product_id, session: Session = Depends(get_session)):
     statement = select(Variance).where(Variance.product_id == product_id)
     variances = session.exec(statement).all()
 
-    variances = [variance.load_relations(relations_to_load=["product"]) for variance in variances]
-
     return variances
 
 @router.get("/{variance_id}")
@@ -32,7 +30,7 @@ def get_variance_by_id(product_id: int, variance_id: int, session: Session = Dep
     if variance is None:
         raise HTTPException(status_code=404, detail="Variance not found.")
 
-    return variance.load_relations(relations_to_load=["product"])
+    return variance
 
 @router.post("/")
 async def create_variance(product_id: int, request: Request, session: Session = Depends(get_session)):
@@ -60,7 +58,7 @@ async def create_variance(product_id: int, request: Request, session: Session = 
 
     session.refresh(new_variance)
 
-    return new_variance.load_relations(relations_to_load=["product"])
+    return new_variance
 
 @router.patch("/{variance_id}")
 async def update_variance(product_id: int, variance_id: int, request: Request, session: Session = Depends(get_session)):
@@ -83,7 +81,7 @@ async def update_variance(product_id: int, variance_id: int, request: Request, s
 
     session.refresh(variance)
 
-    return variance.load_relations(relations_to_load=["product"])
+    return variance
 
 
 

--- a/backend/app/routers/variance_router.py
+++ b/backend/app/routers/variance_router.py
@@ -1,20 +1,21 @@
 from sqlmodel import Session, SQLModel, select
 from models.variance import Variance
 from models.product import Product
-from sqlalchemy.orm import selectinload
 
 from db.engine import DatabaseManager, get_session
 
 from fastapi import APIRouter, Request, HTTPException, Depends
 
 router = APIRouter(
-    prefix="/variances",
+    prefix="/products/{product_id}/variances",
     tags=["variances"]
 )
 
 @router.get("/")
-def get_all_variances(session: Session = Depends(get_session)):
-    statement = select(Variance)
+def get_all_variances(product_id, session: Session = Depends(get_session)):
+    check_product_exists(product_id)
+
+    statement = select(Variance).where(Variance.product_id == product_id)
     variances = session.exec(statement).all()
 
     variances = [variance.load_relations(relations_to_load=["product"]) for variance in variances]
@@ -22,7 +23,9 @@ def get_all_variances(session: Session = Depends(get_session)):
     return variances
 
 @router.get("/{variance_id}")
-def get_variance_by_id(variance_id: int, session: Session = Depends(get_session)):
+def get_variance_by_id(product_id: int, variance_id: int, session: Session = Depends(get_session)):
+    check_product_exists(product_id)
+
     statement = select(Variance).where(Variance.id == variance_id)
     variance = session.exec(statement).first()
 
@@ -32,10 +35,11 @@ def get_variance_by_id(variance_id: int, session: Session = Depends(get_session)
     return variance.load_relations(relations_to_load=["product"])
 
 @router.post("/")
-async def create_variance(request: Request, session: Session = Depends(get_session)):
+async def create_variance(product_id: int, request: Request, session: Session = Depends(get_session)):
+    check_product_exists(product_id)
+
     user_data = await request.json()
 
-    product_id = user_data.get("product_id")
     name = user_data.get("name")
     variance_type = user_data.get("variance_type")
     price = user_data.get("price")
@@ -59,7 +63,9 @@ async def create_variance(request: Request, session: Session = Depends(get_sessi
     return new_variance.load_relations(relations_to_load=["product"])
 
 @router.patch("/{variance_id}")
-async def update_variance(variance_id: int, request: Request, session: Session = Depends(get_session)):
+async def update_variance(product_id: int, variance_id: int, request: Request, session: Session = Depends(get_session)):
+    check_product_exists(product_id)
+
     data = await request.json()
 
     statement = select(Variance).where(Variance.id == variance_id)
@@ -67,9 +73,6 @@ async def update_variance(variance_id: int, request: Request, session: Session =
 
     if variance is None:
         raise HTTPException(status_code=404, detail="Variance not found.")
-
-    if "product_id" in data:
-        raise HTTPException(status_code=400, detail="product_id cannot be updated.")
 
     for key, value in data.items():
         if value is not None and hasattr(variance, key):
@@ -85,7 +88,9 @@ async def update_variance(variance_id: int, request: Request, session: Session =
 
 
 @router.delete("/{variance_id}")
-def delete_user(variance_id: int, session: Session = Depends(get_session)):
+def delete_user(product_id: int, variance_id: int, session: Session = Depends(get_session)):
+    check_product_exists(product_id)
+
     variance = session.get(Variance, variance_id)
 
     if variance is None:
@@ -95,3 +100,10 @@ def delete_user(variance_id: int, session: Session = Depends(get_session)):
     session.commit()
 
     return {"message": "Variance deleted successfully."}
+
+def check_product_exists(product_id: int):
+    statement = select(Product).where(Product.id == product_id)
+    product = get_session().exec(statement).first()
+
+    if product is None:
+        raise HTTPException(status_code=404, detail="Product not found.")

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -1,0 +1,14 @@
+from celery import Celery
+
+celery_app = Celery(
+    "tasks",
+    broker="redis://redis:6379/0",
+    backend="redis://redis:6379/0"
+)
+
+celery_app.conf.update(
+    task_routes={
+        "tasks.orders.*": {"queue": "orders_queue"},
+    }
+)
+celery_app.autodiscover_tasks(["app.models"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,15 @@ services:
     networks:
       - webshop-network
 
+  redis:
+    image: redis:latest
+    container_name: redis
+    restart: always
+    ports:
+      - "6379:6379"
+    networks:
+      - webshop-network
+
   webshop:
     build: backend
     container_name: webshop-backend
@@ -24,8 +33,29 @@ services:
                   # because this keeps the credentials locally in the .env.
       DB_URL_PROD: ${DB_URL_PROD}
       DB_URL_LOCAL: ${DB_URL_LOCAL}
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL}
+      CELERY_RESULT_BACKEND: ${CELERY_RESULT_BACKEND}
     depends_on:
       - db
+      - redis
+    networks:
+      - webshop-network
+
+  celery-worker:
+    build: backend
+    container_name: celery-worker
+    working_dir: /backend/app
+    command: [ "celery", "-A", "tasks.celery_app", "worker", "--loglevel=info" ]
+    environment:
+      PYTHONPATH: /backend/app
+      DB_URL_PROD: ${DB_URL_PROD}
+      DB_URL_LOCAL: ${DB_URL_LOCAL}
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
+      - webshop
     networks:
       - webshop-network
 


### PR DESCRIPTION
The variances router and the general API was a bit refactored. The variances are always related to a product so I thought it would be better to have a "relative" URL for the variances based on the product the belong to. This means the base URL for the variances section is `/products/{product_id}/variances`. Additionally, the variances itself won't have the product as a relation in the response anymore. In my opinion this is not necessary anymore because when accessing a variance via the "relative" product URL we know about which product we are talking and don't need to fetch that as well. This might be changed in the future again, if the necessity occurs.

When requesting any variance this now depends on a product so checks were built which check if the product for which a variance is requested, changed, edited or deleted exists. If it doesn't an according response will be send.